### PR TITLE
Fix server environment

### DIFF
--- a/lib/notice.erb
+++ b/lib/notice.erb
@@ -6,6 +6,10 @@
     <version><%=h notifier_version %></version>
     <url><%=h notifier_url %></url>
   </notifier>
+  <server-environment>
+    <project-root><%=h project_root %></project-root>
+    <environment-name><%=h framework_env %></environment-name>
+  </server-environment>
   <error>
     <class><%=h error.class.name %></class>
     <message><%=h "#{error.class.name}: #{error.message}" %></message>
@@ -43,8 +47,4 @@
     </cgi-data>
     <%- end -%>
   </request>
-  <server-environment>
-    <project-root><%=h project_root %></project-root>
-    <environment-name><%=h framework_env %></environment-name>
-  </server-environment>
 </notice>


### PR DESCRIPTION
For some reason the server environment node has to be in the top, otherwise the tests are failing:

```
  1) Failure:
test_posting(Toadhopper::TestPosting) [test/test_posting.rb:7]:
<["No project exists with the given API key."]> expected but was
<["Element 'notice': Missing child element(s). Expected is ( server-environment ).",
 "No project exists with the given API key."]>

diff:
+ ["Element 'notice': Missing child element(s). Expected is ( server-environment ).",
? ["No project exists with the given API key."]
?                                              

  2) Failure:
test_posting_integration(Toadhopper::TestPosting) [test/test_posting.rb:14]:
<200> expected but was
<422>

diff:
?  200
? 4 2 
```
