### PR TITLE
Removed serializable check when cleaning values

### DIFF
--- a/lib/toadhopper.rb
+++ b/lib/toadhopper.rb
@@ -164,7 +164,7 @@ class Toadhopper
     if filters.any? {|f| key.to_s =~ Regexp.new(f)}
       FILTER_REPLACEMENT
     else
-      value
+      value.to_s
     end
   end
 end

--- a/test/test_filtering.rb
+++ b/test/test_filtering.rb
@@ -9,8 +9,8 @@ class Toadhopper::TestFiltering < Test::Unit::TestCase
     assert_filtered "sensitive", /sit/
   end
 
-  def test_not_cleaning_time_value
-    time = Time.mktime(2011, 03, 15)
+  def test_converting_values_to_string
+    time = Time.mktime(2011, 03, 15).to_s
     assert_equal({:time => time}, toadhopper.send(:clean, :time => time))
   end
 


### PR DESCRIPTION
I encountered problem when passing my own params to toadhopper.
One of values was Time object and clean method just removed this key from hash, because of serializable check (only classes from this method were passed).
I'm not really sure why this check is needed, so I removed it, however if you think it should stay, please find some other solution to this problem.
