### PR TITLE
Adding support for posting notices via https

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ You can install it via rubygems:
 
     gem install toadhopper
 
+## SSL
+
+Toadhopper can transport your messages over SSL.
+
+In order to enable SSL, just add the `:secure` option.
+
+    Toadhopper.new("YOURAPIKEY", :secure => true).post!(e)
+
+Alternatively, you can specify a `:notify_host` with a https:// protocol.
+
+    Toadhopper.new("YOURAPIKEY", :notify_host => 'https://airbrakeapp.com').post!(e)
+
+_Note: You must have a paid plan for Airbrake to accept your messages over SSL._
+
 ## Deploy tracking
 
 You can use Toadhopper to notify Airbrake of deployments:
@@ -39,6 +53,12 @@ Install Bundler 0.9.x, then:
 If you set a `AIRBRAKE_API_KEY` environment variable it'll test actually posting to the Airbrake API. For example:
 
     % bundle exec rake test AIRBRAKE_API_KEY=abc123
+
+Set SECURE=1 to test posting over SSL. For example:
+
+    % bundle exec rake test AIRBRAKE_API_KEY=abc123 SECURE=1
+
+_Note: You must have a paid plan for Airbrake to accept your messages over SSL._
 
 To generate the docs:
 

--- a/lib/toadhopper_exception.rb
+++ b/lib/toadhopper_exception.rb
@@ -1,0 +1,1 @@
+class ToadhopperException < StandardError; end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,7 +6,11 @@ require 'toadhopper'
 FakeWeb.allow_net_connect = true
 
 def toadhopper
-  @toadhopper ||= Toadhopper.new(ENV['AIRBRAKE_API_KEY'] || ENV['HOPTOAD_API_KEY'] || "test api key")
+  @toadhopper ||= Toadhopper.new(ENV['AIRBRAKE_API_KEY'] || ENV['HOPTOAD_API_KEY'] || "test api key", toadhopper_args)
+end
+
+def toadhopper_args
+  ENV['SECURE'] ? {:secure => true} : {}
 end
 
 def error

--- a/test/test_initialization.rb
+++ b/test/test_initialization.rb
@@ -1,0 +1,35 @@
+require 'helper'
+
+class Toadhopper::TestInitialization < Test::Unit::TestCase
+  MY_KEY = 'my key'
+
+  def test_no_params
+    toad = Toadhopper.new MY_KEY
+    assert_toad_behavior toad
+    assert_equal 'http://airbrakeapp.com', toad.notify_host
+  end
+
+  def test_https_host
+    secure_host = 'https://example.com'
+    toad = Toadhopper.new MY_KEY, :notify_host => secure_host
+    assert_toad_behavior toad
+    assert_equal secure_host, toad.notify_host
+  end
+
+  def test_secure
+    toad = Toadhopper.new MY_KEY, :secure => true
+    assert_toad_behavior toad
+    assert_equal 'https://airbrakeapp.com', toad.notify_host
+  end
+
+  def test_secure_and_host_not_allowed
+    assert_raise(ToadhopperException) do
+      Toadhopper.new MY_KEY, :secure => true, :notify_host => 'http://foo.com'
+    end
+  end
+
+  def assert_toad_behavior(toad)
+    assert_kind_of Toadhopper, toad
+    assert_equal MY_KEY, toad.api_key
+  end
+end


### PR DESCRIPTION
Howdy!  Great gem!

I threw in SSL support for those who want to post their notices over https (supported on paid plans only).

On an _unrelated_ note, should we change the default domain (yet again) to airbrake.io?  It looks like that's the preferred domain based on the [API Docs](http://help.airbrake.io/kb/api-2/notifier-api-version-22).

Many thanks,

Stephen
